### PR TITLE
Merge ApplicationClass to Dev

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,4 +25,6 @@ dependencies {
     compile 'com.android.support:design:24.2.1'
     compile 'com.android.support:support-v4:24.2.1'
     testCompile 'junit:junit:4.12'
+    androidTestCompile 'com.android.support:support-annotations:24.2.1'
+    androidTestCompile 'com.android.support.test:runner:0.5'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="letseat.mealdesigner">
 
     <application
+        android:name=".MealDesignerApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/letseat/mealdesigner/MealDesignerApp.java
+++ b/app/src/main/java/letseat/mealdesigner/MealDesignerApp.java
@@ -6,11 +6,16 @@ import android.util.Log;
 import letseat.mealdesigner.long_term_memory.Long_Term_Interface;
 
 /**
+ * This Is the application class for meal designer.
+ * It extends the default class adding:
+ *      -A instance variable for the Long_Term_Interface object
+ *      -It instantiates the Long_Term_Interface object
+ *      -It provides a getter for the Long_Term_Interface object
  * Created by shawn on 10/12/16.
  */
 
 public class MealDesignerApp extends Application {
-    private Long_Term_Interface _storage;
+    private Long_Term_Interface _storage; //Global Long_Term_Interface object
 
     @Override
     public void onCreate(){
@@ -18,6 +23,10 @@ public class MealDesignerApp extends Application {
         super.onCreate();
     }
 
+    /***
+     * This is a getter method for the global Long_Term_Interface
+     * @return a Long_Term_Interface object
+     */
     public Long_Term_Interface getLTI(){
         return _storage;
     }

--- a/app/src/main/java/letseat/mealdesigner/MealDesignerApp.java
+++ b/app/src/main/java/letseat/mealdesigner/MealDesignerApp.java
@@ -1,0 +1,25 @@
+package letseat.mealdesigner;
+
+import android.app.Application;
+import android.util.Log;
+
+import letseat.mealdesigner.long_term_memory.Long_Term_Interface;
+
+/**
+ * Created by shawn on 10/12/16.
+ */
+
+public class MealDesignerApp extends Application {
+    private Long_Term_Interface _storage;
+
+    @Override
+    public void onCreate(){
+        _storage = new Long_Term_Interface(this);
+        super.onCreate();
+    }
+
+    public Long_Term_Interface getLTI(){
+        return _storage;
+    }
+
+}

--- a/app/src/main/java/letseat/mealdesigner/long_term_memory/Long_Term_Interface.java
+++ b/app/src/main/java/letseat/mealdesigner/long_term_memory/Long_Term_Interface.java
@@ -1,5 +1,6 @@
 package letseat.mealdesigner.long_term_memory;
 
+import android.app.Application;
 import android.content.Context;
 
 import java.io.BufferedReader;
@@ -15,7 +16,7 @@ import java.util.HashMap;
 import java.util.Date;
 
 import letseat.mealdesigner.MainActivity;
-
+import letseat.mealdesigner.MealDesignerApp;
 
 
 /**
@@ -37,14 +38,14 @@ public class Long_Term_Interface
     private static final double INDEX_FILE_TOLERANCE = 2.5;
 
 
-    private MainActivity _top;
+    private Application _top;
     private File _appHomeDir;                           // the internal directory of the app
     private static final String EXTENSION = ".scgc";    // this can be changed, but all files which exist with the outdated extension need to be updated
     private static final String DEFAULT = "default_filename_";  // the default filename to be used if a given filename is invalid
 
 
 
-    public Long_Term_Interface(MainActivity top)
+    public Long_Term_Interface(Application top)
     {
         _top = top;
         _appHomeDir = _top.getFilesDir();


### PR DESCRIPTION
- Instantiates the long term interface globaly so that only one exists
- Each activity can access the object by calling: 
             Long_Term_Interface x = ((MealDesignerApp) getApplication()).getLTI();
- The above retrieves the Long_Term_Interface and stores it in x, you should however probably make sure to store it in an instance variable 
